### PR TITLE
Loading and spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# CHANGELOG
+
+# v1.1.0
+- Added `pdfView_page_margin` as an attribute to change spacing (Right, Left, Top, Bottom) from the pages Or use the following attribute to add space for each edges:
+```xml
+<com.rajat.pdfviewer.PdfRendererView
+    android:id="@+id/pdfView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:pdfView_divider="@drawable/divider"
+    app:pdfView_engine="internal"
+    app:pdfView_enableLoadingForPages="true"
+    app:pdfView_page_marginRight="10dp"
+    app:pdfView_page_marginLeft="10dp"
+    app:pdfView_page_marginTop="5dp"
+    app:pdfView_page_marginBottom="5dp"
+/> 
+```
+
+- Added loading view for each pages. It's available by using `pdfView_enableLoadingForPages` attribute.
+- Optimise rendering PDF process by using `CoroutineScope` instead of `GlobalScope`
+
+## Breaking Changes
+- Added night/light mode background for `PdfViewerActivity`. If you enable spacing it would show background of this activity.
+- Remove background from the list of pages (`PinchZoomRecyclerView`) to let developers to add custom background for PDF viewer. It may affect to see the PDF viewer result by showing the parent background.

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererCore.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererCore.kt
@@ -10,10 +10,7 @@ import android.graphics.pdf.PdfRenderer
 import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -91,10 +88,10 @@ internal class PdfRendererCore(
         if (pageNo >= getPageCount())
             return
 
-        GlobalScope.async {
+        CoroutineScope(Dispatchers.IO).launch {
             synchronized(this@PdfRendererCore) {
                 buildBitmap(pageNo) { bitmap ->
-                    GlobalScope.launch(Dispatchers.Main) { onBitmapReady?.invoke(bitmap, pageNo) }
+                    CoroutineScope(Dispatchers.Main).launch { onBitmapReady?.invoke(bitmap, pageNo) }
                 }
                 onBitmapReady?.let {
                     //prefetchNext(pageNo + 1)
@@ -116,8 +113,6 @@ internal class PdfRendererCore(
             onBitmap(it)
             return@buildBitmap
         }
-
-        val startTime = System.currentTimeMillis()
 
         try {
             val pdfPage = pdfRenderer!!.openPage(pageNo)

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererCore.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererCore.kt
@@ -59,6 +59,11 @@ internal class PdfRendererCore(
             null
         }
     }
+    fun pageExistInCache(pageNo: Int): Boolean {
+        val loadPath = File(File(context.cacheDir, cachePath), pageNo.toString())
+
+        return loadPath.exists()
+    }
 
     @Throws(IOException::class)
     private fun writeBitmapToCache(pageNo: Int, bitmap: Bitmap) {

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -41,6 +41,8 @@ class PdfRendererView @JvmOverloads constructor(
     private var showDivider = true
     private var divider: Drawable? = null
     private var runnable = Runnable {}
+    var enableLoadingForPages: Boolean = false
+
     private var pdfRendererCoreInitialised = false
     var pageMargin: Rect = Rect(0,0,0,0)
     var statusListener: StatusCallBack? = null
@@ -234,9 +236,9 @@ class PdfRendererView @JvmOverloads constructor(
         engine = PdfEngine.values().first { it.value == engineValue }
         showDivider = typedArray.getBoolean(R.styleable.PdfRendererView_pdfView_showDivider, true)
         divider = typedArray.getDrawable(R.styleable.PdfRendererView_pdfView_divider)
+        enableLoadingForPages = typedArray.getBoolean(R.styleable.PdfRendererView_pdfView_enableLoadingForPages, enableLoadingForPages)
 
         val marginDim = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_margin, 0)
-
         pageMargin = Rect(marginDim, marginDim, marginDim, marginDim).apply {
             top = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginTop, top)
             left = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginLeft, left)

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -3,6 +3,7 @@ package com.rajat.pdfviewer
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.AttributeSet
@@ -41,8 +42,9 @@ class PdfRendererView @JvmOverloads constructor(
     private var divider: Drawable? = null
     private var runnable = Runnable {}
     private var pdfRendererCoreInitialised = false
-
+    var pageMargin: Rect = Rect(0,0,0,0)
     var statusListener: StatusCallBack? = null
+
     val totalPageCount: Int
         get() {
             return pdfRendererCore.getPageCount()
@@ -107,7 +109,7 @@ class PdfRendererView @JvmOverloads constructor(
     private fun init(file: File, pdfQuality: PdfQuality) {
         pdfRendererCore = PdfRendererCore(context, file, pdfQuality)
         pdfRendererCoreInitialised = true
-        pdfViewAdapter = PdfViewAdapter(pdfRendererCore)
+        pdfViewAdapter = PdfViewAdapter(pdfRendererCore, pageMargin, enableLoadingForPages)
         val v = LayoutInflater.from(context).inflate(R.layout.pdf_rendererview, this, false)
         addView(v)
         recyclerView = findViewById(R.id.recyclerView)
@@ -232,6 +234,16 @@ class PdfRendererView @JvmOverloads constructor(
         engine = PdfEngine.values().first { it.value == engineValue }
         showDivider = typedArray.getBoolean(R.styleable.PdfRendererView_pdfView_showDivider, true)
         divider = typedArray.getDrawable(R.styleable.PdfRendererView_pdfView_divider)
+
+        val marginDim = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_margin, 0)
+
+        pageMargin = Rect(marginDim, marginDim, marginDim, marginDim).apply {
+            top = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginTop, top)
+            left = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginLeft, left)
+            right = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginRight, right)
+            bottom = typedArray.getDimensionPixelSize(R.styleable.PdfRendererView_pdfView_page_marginBottom, bottom)
+
+        }
 
         typedArray.recycle()
     }

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -41,6 +41,8 @@ internal class PdfViewAdapter(
     inner class PdfPageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         fun bind(position: Int) {
             with(itemView) {
+                handleLoadingForPage(position)
+
                 pageView.setImageBitmap(null)
                 renderer.renderPage(position) { bitmap: Bitmap?, pageNo: Int ->
                     if (pageNo != position)
@@ -59,8 +61,23 @@ internal class PdfViewAdapter(
                             interpolator = LinearInterpolator()
                             duration = 300
                         }
+
+                        pdf_view_page_loading_progress.hide()
                     }
                 }
+            }
+        }
+
+        private fun View.handleLoadingForPage(position: Int) {
+            if (!enableLoadingForPages) {
+                pdf_view_page_loading_progress.hide()
+                return
+            }
+
+            if (renderer.pageExistInCache(position)) {
+                pdf_view_page_loading_progress.hide()
+            } else {
+                pdf_view_page_loading_progress.show()
             }
         }
     }

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -1,23 +1,32 @@
 package com.rajat.pdfviewer
 
+import android.view.View
+import android.graphics.Rect
+import android.view.ViewGroup
 import android.graphics.Bitmap
 import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import com.rajat.pdfviewer.util.hide
+import com.rajat.pdfviewer.util.show
 import android.view.animation.AlphaAnimation
+import androidx.core.view.updateLayoutParams
 import android.view.animation.LinearInterpolator
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.list_item_pdf_page.view.*
+import kotlinx.android.synthetic.main.pdf_view_page_loading_layout.view.*
 
 /**
  * Created by Rajat on 11,July,2020
  */
 
-internal class PdfViewAdapter(private val renderer: PdfRendererCore) :
+internal class PdfViewAdapter(
+    private val renderer: PdfRendererCore,
+    private val pageSpacing: Rect,
+    private val enableLoadingForPages: Boolean
+) :
     RecyclerView.Adapter<PdfViewAdapter.PdfPageViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PdfPageViewHolder {
-        val v =
-            LayoutInflater.from(parent.context).inflate(R.layout.list_item_pdf_page, parent, false)
+        val v = LayoutInflater.from(parent.context)
+                .inflate(R.layout.list_item_pdf_page, parent, false)
         return PdfPageViewHolder(v)
     }
 
@@ -26,20 +35,24 @@ internal class PdfViewAdapter(private val renderer: PdfRendererCore) :
     }
 
     override fun onBindViewHolder(holder: PdfPageViewHolder, position: Int) {
-        holder.bind()
+        holder.bind(position)
     }
 
     inner class PdfPageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        fun bind() {
+        fun bind(position: Int) {
             with(itemView) {
                 pageView.setImageBitmap(null)
-                renderer.renderPage(adapterPosition) { bitmap: Bitmap?, pageNo: Int ->
-                    if (pageNo != adapterPosition)
+                renderer.renderPage(position) { bitmap: Bitmap?, pageNo: Int ->
+                    if (pageNo != position)
                         return@renderPage
                     bitmap?.let {
-                        pageView.layoutParams = pageView.layoutParams.apply {
+                        pageView.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                             height =
                                 (pageView.width.toFloat() / ((bitmap.width.toFloat() / bitmap.height.toFloat()))).toInt()
+                            this.topMargin = pageSpacing.top
+                            this.leftMargin = pageSpacing.left
+                            this.rightMargin = pageSpacing.right
+                            this.bottomMargin = pageSpacing.bottom
                         }
                         pageView.setImageBitmap(bitmap)
                         pageView.animation = AlphaAnimation(0F, 1F).apply {

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -48,7 +48,7 @@ internal class PdfViewAdapter(
                     if (pageNo != position)
                         return@renderPage
                     bitmap?.let {
-                        pageView.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                        container_view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                             height =
                                 (pageView.width.toFloat() / ((bitmap.width.toFloat() / bitmap.height.toFloat()))).toInt()
                             this.topMargin = pageSpacing.top

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -50,7 +50,7 @@ internal class PdfViewAdapter(
                     bitmap?.let {
                         container_view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                             height =
-                                (pageView.width.toFloat() / ((bitmap.width.toFloat() / bitmap.height.toFloat()))).toInt()
+                                (container_view.width.toFloat() / ((bitmap.width.toFloat() / bitmap.height.toFloat()))).toInt()
                             this.topMargin = pageSpacing.top
                             this.leftMargin = pageSpacing.left
                             this.rightMargin = pageSpacing.right

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/util/ViewExt.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/util/ViewExt.kt
@@ -1,0 +1,11 @@
+package com.rajat.pdfviewer.util
+
+import android.view.View
+
+fun View.show() {
+    this.visibility = View.VISIBLE
+}
+
+fun View.hide() {
+    this.visibility = View.GONE
+}

--- a/pdfViewer/src/main/res/layout/activity_pdf_viewer.xml
+++ b/pdfViewer/src/main/res/layout/activity_pdf_viewer.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:background="?attr/pdfView_backgroundColor"
     tools:context=".PdfViewerActivity">
 
     <include layout="@layout/pdf_view_tool_bar" />

--- a/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
+++ b/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="0dp"
-        android:layout_weight="2"
         android:background="#ffffff"
         android:contentDescription="@string/content_des"
         android:padding="0dp"

--- a/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
+++ b/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
@@ -2,7 +2,9 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="480dp">
+    android:layout_height="480dp"
+    android:id="@+id/container_view"
+    >
 
     <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/pageView"

--- a/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
+++ b/pdfViewer/src/main/res/layout/list_item_pdf_page.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/pageView"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="480dp"
-    android:layout_margin="0dp"
-    android:background="#ffffff"
-    android:contentDescription="@string/content_des"
-    android:padding="0dp"
-    android:scaleType="fitCenter" />
+    android:layout_height="480dp">
+
+    <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/pageView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="0dp"
+        android:layout_weight="2"
+        android:background="#ffffff"
+        android:contentDescription="@string/content_des"
+        android:padding="0dp"
+        android:scaleType="fitCenter" />
+
+    <include
+        layout="@layout/pdf_view_page_loading_layout"/>
+
+</FrameLayout>

--- a/pdfViewer/src/main/res/layout/pdf_rendererview.xml
+++ b/pdfViewer/src/main/res/layout/pdf_rendererview.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <com.rajat.pdfviewer.PinchZoomRecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/white"
-        android:scrollbars="vertical" />
+        android:background="@android:color/transparent"
+        android:scrollbars="vertical"
+        tools:listitem="@layout/list_item_pdf_page" />
 
     <WebView
         android:id="@+id/webView"

--- a/pdfViewer/src/main/res/layout/pdf_view_page_loading_layout.xml
+++ b/pdfViewer/src/main/res/layout/pdf_view_page_loading_layout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/pdf_view_page_loading_progress"
+        android:layout_gravity="center"
+        android:layout_width="40dp"
+        android:layout_height="40dp"/>
+
+</FrameLayout>

--- a/pdfViewer/src/main/res/values/attrs.xml
+++ b/pdfViewer/src/main/res/values/attrs.xml
@@ -12,6 +12,12 @@
         </attr>
         <attr name="pdfView_showDivider" format="boolean" />
         <attr name="pdfView_divider" format="reference" />
+
+        <attr name="pdfView_page_margin" format="reference|dimension"  />
+        <attr name="pdfView_page_marginLeft" format="reference|dimension"  />
+        <attr name="pdfView_page_marginTop" format="reference|dimension" />
+        <attr name="pdfView_page_marginRight" format="reference|dimension"  />
+        <attr name="pdfView_page_marginBottom" format="reference|dimension"  />
     </declare-styleable>
 
     <!-- icons -->
@@ -26,4 +32,5 @@
     <attr name="pdfView_titleTextStyle" format="reference" />
 
     <attr name="pdfView_progressBar" format="reference"/>
+    <attr name="pdfView_backgroundColor" format="reference|color"/>
 </resources>

--- a/pdfViewer/src/main/res/values/attrs.xml
+++ b/pdfViewer/src/main/res/values/attrs.xml
@@ -13,6 +13,8 @@
         <attr name="pdfView_showDivider" format="boolean" />
         <attr name="pdfView_divider" format="reference" />
 
+        <attr name="pdfView_enableLoadingForPages" format="reference|boolean" />
+
         <attr name="pdfView_page_margin" format="reference|dimension"  />
         <attr name="pdfView_page_marginLeft" format="reference|dimension"  />
         <attr name="pdfView_page_marginTop" format="reference|dimension" />

--- a/pdfViewer/src/main/res/values/themes.xml
+++ b/pdfViewer/src/main/res/values/themes.xml
@@ -10,6 +10,7 @@
         <item name="pdfView_actionBarTint">#000000</item>
         <item name="pdfView_titleTextStyle">@style/pdfView_titleTextAppearance</item>
         <item name="pdfView_progressBar">@style/pdfView_progressBarStyle</item>
+        <item name="pdfView_backgroundColor">#EAEAEA</item>
     </style>
 
     <style name="Theme.PdfView.Dark" parent="@style/Theme.AppCompat.Light.NoActionBar">
@@ -19,6 +20,7 @@
         <item name="pdfView_actionBarTint">#ffffff</item>
         <item name="pdfView_titleTextStyle">@style/pdfView_titleTextAppearanceDark</item>
         <item name="pdfView_progressBar">@style/pdfView_progressBarStyle</item>
+        <item name="pdfView_backgroundColor">#100F0F</item>
     </style>
 
     <style name="pdfView_titleTextAppearance" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">


### PR DESCRIPTION
- Added `pdfView_page_margin` as an attribute to change spacing (Right, Left, Top, Bottom) from the pages Or use the following attribute to add space for each edges:
```XML
<com.rajat.pdfviewer.PdfRendererView
    android:id="@+id/pdfView"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    app:pdfView_divider="@drawable/divider"
    app:pdfView_engine="internal"
    app:pdfView_enableLoadingForPages="true"
    app:pdfView_page_marginRight="10dp"
    app:pdfView_page_marginLeft="10dp"
    app:pdfView_page_marginTop="5dp"
    app:pdfView_page_marginBottom="5dp"
/> 
```

- Added loading view for each page. It's available by using `pdfView_enableLoadingForPages` attribute.
- Optimise rendering PDF process by using `CoroutineScope` instead of `GlobalScope`

## Breaking Changes
- Added night/light mode background for `PdfViewerActivity.` If you enable spacing, it will show the background of this activity.
- Remove background from the list of pages (`PinchZoomRecyclerView`) to let developers add a custom background for PDF viewer. It may affect to see the PDF viewer result by showing the parent background.

Gif:
![ezgif-1-7e7bce22d1](https://user-images.githubusercontent.com/27139702/205109350-717a1488-e211-4799-85a4-e93573f702b9.gif)