### PR TITLE
Support multi language apps

### DIFF
--- a/pdfViewer/src/main/res/values/strings.xml
+++ b/pdfViewer/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="pdfView_appName">Pdf View</string>
     <string name="content_des">PDF PAGE</string>
-    <string name="pdfView_page_no">%1$d of %2$d</string>
+    <string name="pdfView_page_no">%1$d/%2$d</string>
 </resources>


### PR DESCRIPTION
In multi-langue app must not be 'of'. I would say this fix should be good enough, or there must be a way how to configure PdfRendererView in another way.

And for future deployment, I would recommend you remove the Wrapping activity and let only the View itself that will work only with local files. In this way, the library would be more flexible and more attractive for developers.