### PR TITLE
change multidex dependency namespace to androidX

### DIFF
--- a/pdfViewer/build.gradle
+++ b/pdfViewer/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3'
     implementation 'com.google.android.material:material:1.7.0'
-    implementation 'com.android.support:multidex:2.0.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'


### PR DESCRIPTION
Change multidex dependency namespace to androidX to avoid jetifier. 