### PR TITLE
Replace "Global Scope" with "lifeCycleScope"

### DIFF
--- a/pdfViewer/build.gradle
+++ b/pdfViewer/build.gradle
@@ -35,6 +35,8 @@ android {
 }
 
 dependencies {
+    def lifecycle_version = "2.4.1"
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.9.0'
@@ -49,4 +51,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-common:$lifecycle_version"
 }

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -15,12 +15,16 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import kotlinx.android.synthetic.main.pdf_rendererview.view.*
+import kotlinx.coroutines.CoroutineScope
 import java.io.File
 import java.net.URLEncoder
 
@@ -63,7 +67,8 @@ class PdfRendererView @JvmOverloads constructor(
     fun initWithUrl(
         url: String,
         pdfQuality: PdfQuality = this.quality,
-        engine: PdfEngine = this.engine
+        engine: PdfEngine = this.engine,
+        lifecycleScope: LifecycleCoroutineScope = (context as AppCompatActivity).lifecycleScope
     ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || engine == PdfEngine.GOOGLE) {
             initUnderKitkat(url)
@@ -93,6 +98,8 @@ class PdfRendererView @JvmOverloads constructor(
                 error.printStackTrace()
                 statusListener?.onError(error)
             }
+
+            override fun getCoroutineScope(): CoroutineScope = lifecycleScope
         })
     }
 


### PR DESCRIPTION
I have replaced the "GlobalScope" with lifecycle-aware "lifeCycleScope". I'll create another MR to open a protected url later.