### PR TITLE
Storage permissions not required in  api version > 30 

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewerActivity.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewerActivity.kt
@@ -286,11 +286,15 @@ class PdfViewerActivity : AppCompatActivity() {
     }
 
     private fun checkPermissionOnInit() {
-        if (ContextCompat.checkSelfPermission(
-                this,
-                permission.WRITE_EXTERNAL_STORAGE
-            ) === PackageManager.PERMISSION_GRANTED
-        ) {
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.R){
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    permission.WRITE_EXTERNAL_STORAGE
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                permissionGranted = true
+            }
+        }else{
             permissionGranted = true
         }
     }


### PR DESCRIPTION
Storage permissions not required to save file in Download directory when targetSdkVersion > 30 (Android 11