### PR TITLE
Add compose Modifier parameter to PdfRendererViewCompose

### DIFF
--- a/app/src/main/java/com/rajat/sample/pdfviewer/ComposeActivity.kt
+++ b/app/src/main/java/com/rajat/sample/pdfviewer/ComposeActivity.kt
@@ -33,7 +33,10 @@ class ComposeActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    MyPdfScreenFromUrl(download_file_url2)
+                    MyPdfScreenFromUrl(
+                        url = download_file_url2,
+                        modifier = Modifier.fillMaxSize()
+                    )
                 }
             }
         }
@@ -41,9 +44,10 @@ class ComposeActivity : ComponentActivity() {
 }
 
 @Composable
-fun MyPdfScreenFromUrl(url: String) {
+fun MyPdfScreenFromUrl(url: String, modifier: Modifier = Modifier) {
     val lifecycleOwner = LocalLifecycleOwner.current
     PdfRendererViewCompose(
+        modifier = modifier,
         url = url,
         lifecycleOwner = lifecycleOwner,
         statusCallBack = object : PdfRendererView.StatusCallBack {

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
@@ -1,6 +1,7 @@
 package com.rajat.pdfviewer.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.LifecycleOwner
@@ -11,6 +12,7 @@ import java.io.File
 
 @Composable
 fun PdfRendererViewCompose(
+    modifier: Modifier = Modifier,
     url: String? = null,
     file: File? = null,
     headers: HeaderData = HeaderData(),
@@ -34,6 +36,7 @@ fun PdfRendererViewCompose(
         },
         update = { view ->
             // Update logic if needed
-        }
+        },
+        modifier = modifier
     )
 }


### PR DESCRIPTION
I tried to add the component PdfRendererViewCompose to my project using Jetpack Compose and it does not show in my case (I put it in a HorizontalPager). I rewrited it with a modifier parameter and it works like a charm.

So I think we should add modifier param to the component. It is also the best practice for every Compose components.