### PR TITLE
Support init PdfRendererView with Uri

### DIFF
--- a/app/src/main/java/com/rajat/sample/pdfviewer/ComposeActivity.kt
+++ b/app/src/main/java/com/rajat/sample/pdfviewer/ComposeActivity.kt
@@ -1,17 +1,30 @@
 package com.rajat.sample.pdfviewer
 
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.rajat.pdfviewer.PdfRendererView
 import com.rajat.pdfviewer.compose.PdfRendererViewCompose
 import com.rajat.sample.pdfviewer.ui.theme.AndroidpdfviewerTheme
@@ -22,7 +35,8 @@ class ComposeActivity : ComponentActivity() {
     private var download_file_url = "https://css4.pub/2015/usenix/example.pdf"
     private var download_file_url1 = "https://css4.pub/2017/newsletter/drylab.pdf"
     private var download_file_url2 = "https://css4.pub/2015/textbook/somatosensory.pdf"
-    private var download_file_url3 = "https://file-examples.com/storage/fe19e15eac6560f8c936c41/2017/10/file-example_PDF_1MB.pdf"
+    private var download_file_url3 =
+        "https://file-examples.com/storage/fe19e15eac6560f8c936c41/2017/10/file-example_PDF_1MB.pdf"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,8 +47,7 @@ class ComposeActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    MyPdfScreenFromUrl(
-                        url = download_file_url2,
+                    MyPdfScreenFromUri(
                         modifier = Modifier.fillMaxSize()
                     )
                 }
@@ -44,15 +57,57 @@ class ComposeActivity : ComponentActivity() {
 }
 
 @Composable
-fun MyPdfScreenFromUrl(url: String, modifier: Modifier = Modifier) {
+fun MyPdfScreenFromUri(modifier: Modifier = Modifier) {
+    val (uri, setUri) = rememberSaveable {
+        mutableStateOf<Uri?>(null)
+    }
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+        onResult = setUri
+    )
+
+    Column(modifier = modifier) {
+        AnimatedContent(
+            targetState = uri,
+            label = "",
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1F)
+        ) {
+            if (it != null) {
+                MyPdfScreenFromUri(
+                    uri = it,
+                    modifier = Modifier
+                        .fillMaxSize()
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        ) {
+            Button(
+                onClick = {
+                    launcher.launch(arrayOf("application/pdf"))
+                }
+            ) {
+                Text(text = "Pick PDF file")
+            }
+        }
+    }
+}
+
+@Composable
+fun MyPdfScreenFromUri(uri: Uri, modifier: Modifier = Modifier) {
     val lifecycleOwner = LocalLifecycleOwner.current
     PdfRendererViewCompose(
         modifier = modifier,
-        url = url,
+        uri = uri,
         lifecycleOwner = lifecycleOwner,
         statusCallBack = object : PdfRendererView.StatusCallBack {
             override fun onPdfLoadStart() {
-                Log.i("statusCallBack","onPdfLoadStart")
+                Log.i("statusCallBack", "onPdfLoadStart")
             }
 
             override fun onPdfLoadProgress(
@@ -64,11 +119,46 @@ fun MyPdfScreenFromUrl(url: String, modifier: Modifier = Modifier) {
             }
 
             override fun onPdfLoadSuccess(absolutePath: String) {
-                Log.i("statusCallBack","onPdfLoadSuccess")
+                Log.i("statusCallBack", "onPdfLoadSuccess")
             }
 
             override fun onError(error: Throwable) {
-                Log.i("statusCallBack","onError")
+                Log.i("statusCallBack", "onError")
+            }
+
+            override fun onPageChanged(currentPage: Int, totalPage: Int) {
+                //Page change. Not require
+            }
+        }
+    )
+}
+
+@Composable
+fun MyPdfScreenFromUrl(url: String, modifier: Modifier = Modifier) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    PdfRendererViewCompose(
+        modifier = modifier,
+        url = url,
+        lifecycleOwner = lifecycleOwner,
+        statusCallBack = object : PdfRendererView.StatusCallBack {
+            override fun onPdfLoadStart() {
+                Log.i("statusCallBack", "onPdfLoadStart")
+            }
+
+            override fun onPdfLoadProgress(
+                progress: Int,
+                downloadedBytes: Long,
+                totalBytes: Long?
+            ) {
+                //Download is in progress
+            }
+
+            override fun onPdfLoadSuccess(absolutePath: String) {
+                Log.i("statusCallBack", "onPdfLoadSuccess")
+            }
+
+            override fun onError(error: Throwable) {
+                Log.i("statusCallBack", "onError")
             }
 
             override fun onPageChanged(currentPage: Int, totalPage: Int) {

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.ParcelFileDescriptor
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -26,6 +28,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import com.rajat.pdfviewer.util.PdfEngine
 import java.io.File
+import java.io.FileNotFoundException
 
 /**
  * Created by Rajat on 11,July,2020
@@ -101,6 +104,12 @@ class PdfRendererView @JvmOverloads constructor(
         init(file)
     }
 
+    @Throws(FileNotFoundException::class)
+    fun initWithUri(uri: Uri) {
+        val fileDescriptor = context.contentResolver.openFileDescriptor(uri, "r") ?: return
+        init(fileDescriptor)
+    }
+
     override fun onSaveInstanceState(): Parcelable? {
         val superState = super.onSaveInstanceState()
         val savedState = Bundle()
@@ -127,7 +136,13 @@ class PdfRendererView @JvmOverloads constructor(
     }
 
     private fun init(file: File) {
-        pdfRendererCore = PdfRendererCore(context, file)
+        val fileDescriptor = PdfRendererCore.getFileDescriptor(file)
+        init(fileDescriptor)
+    }
+
+    private fun init(fileDescriptor: ParcelFileDescriptor) {
+        // Proceed with safeFile
+        pdfRendererCore = PdfRendererCore(context, fileDescriptor)
         pdfRendererCoreInitialised = true
         pdfViewAdapter = PdfViewAdapter(context,pdfRendererCore, pageMargin, enableLoadingForPages)
         val v = LayoutInflater.from(context).inflate(R.layout.pdf_rendererview, this, false)

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
@@ -1,5 +1,6 @@
 package com.rajat.pdfviewer.compose
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -15,6 +16,7 @@ fun PdfRendererViewCompose(
     modifier: Modifier = Modifier,
     url: String? = null,
     file: File? = null,
+    uri: Uri? = null,
     headers: HeaderData = HeaderData(),
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     statusCallBack: PdfRendererView.StatusCallBack? = null
@@ -31,6 +33,8 @@ fun PdfRendererViewCompose(
                     initWithFile(file)
                 } else if (url != null) {
                     initWithUrl(url, headers, lifecycleScope, lifecycleOwner.lifecycle)
+                } else if (uri != null) {
+                    initWithUri(uri)
                 }
             }
         },


### PR DESCRIPTION
A disadvantage of this library is that it does not support Uri type while most of othe libraries do. When I tried to get content uri from intent, parse it to file and put it to the constructor, it got a crash because it require storage permissions.

I think class `PdfRenderer` in Android SDK require a `ParcelFileDescriptor` param so we should use it as the default parameter for `PdfRendererCore`.

I also keep the `file` param in a second constructor, therefore no need old users migrate their code to the new constructor.