### PR TITLE
Added Dispatchers.Main coroutine scope when invoking listener.onDownloadStart()

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfDownloader.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfDownloader.kt
@@ -74,7 +74,9 @@ class PdfDownloader(
             withContext(Dispatchers.IO) {
                 var tempFile: File? = null
                 try {
-                    listener.onDownloadStart()
+                    withContext(Dispatchers.Main) {
+                        listener.onDownloadStart()
+                    }
                     val cacheDir = listener.getContext().cacheDir
                     tempFile = File.createTempFile("download_", ".tmp", cacheDir)
                     val urlConnection = URL(downloadUrl).openConnection().apply {


### PR DESCRIPTION
- In the function `download(_: String, _: String)` of `PdfDownloader.kt`, `listener.onDownloadStart()` was being invoked in the `Dispatchers.IO` coroutine context. 

- This is resulting in Exception if the observer of this callback wants to make some UI change on main thread.

- Added `Dispatchers.Main` coroutine scope when invoking `onDownloadStart()` callback.