### PR TITLE
Fix x and y translation issue on double tap

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
@@ -224,8 +224,6 @@ class PinchZoomRecyclerView : RecyclerView {
                 // Adjust position so that it scales towards the double-tap location
                 mPosX -= (e.x - mPosX) * (scaleDelta - 1)
                 mPosY -= (e.y - mPosY) * (scaleDelta - 1)
-
-                clampPosition()
             }
 
             invalidate()

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
@@ -222,8 +222,8 @@ class PinchZoomRecyclerView : RecyclerView {
                 mScaleFactor = targetScale
 
                 // Adjust position so that it scales towards the double-tap location
-                mPosX -= (e.x - mPosX) * (1 - scaleDelta)
-                mPosY -= (e.y - mPosY) * (1 - scaleDelta)
+                mPosX -= (e.x - mPosX) * (scaleDelta - 1)
+                mPosY -= (e.y - mPosY) * (scaleDelta - 1)
 
                 clampPosition()
             }


### PR DESCRIPTION
Fixed the `mPosX` & `mPosY` values so that double tap to zoom does not cause the actual pdf bitmap to go out of screen bounds.

**After applying the fix**

https://github.com/user-attachments/assets/206b0e1c-f817-4204-8dd3-f77a13fa5921
