### PR TITLE
updated README.md by adding min/complie sdk versions description

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ dependencies {
 ```
 
 ### Requirements:
-- Minimum SDK version: 21
+- Minimum SDK version: 23
 - Compile & Target SDK version: 35 (updated since version 2.2.0)
 
 ## How to use the library?

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ dependencies {
 }
 ```
 
+### Requirements:
+- Minimum SDK version: 21
+- Compile & Target SDK version: 35 (updated since version 2.2.0)
+
 ## How to use the library?
 Now you have integrated the library in your project but **how do you use it**? Well it's really easy. Just launch the intent with in following way: (Refer to [MainActivity.kt](https://github.com/afreakyelf/Pdf-Viewer/blob/master/app/src/main/java/com/rajat/sample/pdfviewer/MainActivity.kt) for more details.)
 


### PR DESCRIPTION
This update is important because many projects are either large-scale, commercial, or were created some time ago. Upgrading the compileSdk version is not always quick or straightforward—it can trigger a chain reaction of dependency and compatibility issues. In such cases, it’s crucial to know the required SDK versions to choose the appropriate library version that aligns with local project constraints. Unfortunately, this information was missing from the changelogs of all major releases. I had to research the codebase myself to identify the exact point where the compileSdk was raised from 34 to 35.