### PR TITLE
fix: ensure PdfRendererView always releases resources via onDetachedFromWindow

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -349,6 +349,10 @@ class PdfRendererView @JvmOverloads constructor(
         }
     }
 
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        closePdfRender()
+    }
 
     override fun onSaveInstanceState(): Parcelable {
         val superState = super.onSaveInstanceState()


### PR DESCRIPTION
## Fix: PdfRenderer not being closed when using PdfRendererCompose

Hi!

First off — thanks for the awesome library 🙌 I’ve been happily using it for 2 years now!

### The issue

Currently, I’m on version 2.3.2, and I ran into an issue when using PdfRendererCompose. In my app logs, I kept seeing warnings like:
`A resource failed to call close.`

These appeared when navigating back from a screen using the Compose version of the PDF viewer.

After enabling StrictMode, I got more detailed messages pointing to leaked `ParcelFileDescriptor` and `PdfRenderer` instances — they were not being released properly. Interestingly, this only occurred with `PdfRendererCompose`, not when using the standard `PdfViewerActivity`.

### Investigation

I traced it down to the `closePdfRender()` method:
It is correctly called inside `onDestroy()` when using the regular activity-based flow. But in Compose, that lifecycle method isn’t part of the view stack — so `closePdfRender()` never gets called. This explained the StrictMode violations and resource warnings.

### The fix

This PR adds an override of onDetachedFromWindow() in PdfRendererView and moves the cleanup there by calling closePdfRender(). This ensures that cleanup happens whenever the view is removed from the hierarchy — which is how Compose handles view disposal.

I also reproduced the issue in the sample app using StrictMode, and verified that the leak appears with the Compose screen and disappears after applying this change. ✅

### P.S

This fix is based on what I observed and tested, and it worked well in my case. That said, if there’s a more idiomatic or preferred way to handle this in the library, I’m more than happy to adjust!

Thanks again for the library — it’s been super helpful!