### PR TITLE
Make cache identifier for local file more unique

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -125,7 +125,7 @@ class PdfRendererView @JvmOverloads constructor(
     // Load PDF directly from File
     fun initWithFile(file: File, cacheStrategy: CacheStrategy = CacheStrategy.MAXIMIZE_PERFORMANCE) {
         this.cacheStrategy = cacheStrategy
-        val cacheIdentifier = file.name
+        val cacheIdentifier = "${file.name}_${file.parent?.hashCode()}_${file.length()}"
 
         // Notify loading started
         statusListener?.onPdfLoadStart()


### PR DESCRIPTION
Added parent's path and file length to local's file cache identifier to avoid situations when opening files with the same name.

Bug:
Open local files from different folders but with the same file name and it renders the **first** cached file.
`folder1/name.pdf` (10 pages) => cached in `cache/___pdf___cache___/name.pdf` 10 pages
`folder2/name.pdf` (2 pages) => not cached, renders 2 pages from 2nd file
`folder3/name.pdf` (25 pages) => cached in `cache/___pdf___cache___/name.pdf` 15 **last** pages, renders **first** 10 pages from 1st file