### PR TITLE
Fix: Add missing default implementation for `onPdfRenderStart` in StatusCallBack

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -471,7 +471,7 @@ class PdfRendererView @JvmOverloads constructor(
         fun onPdfLoadSuccess(absolutePath: String) {}
         fun onError(error: Throwable) {}
         fun onPageChanged(currentPage: Int, totalPage: Int) {}
-        fun onPdfRenderStart()
+        fun onPdfRenderStart() {}
         fun onPdfRenderSuccess() {}
     }
 


### PR DESCRIPTION
Fix: Add missing default implementation for `onPdfRenderStart` in StatusCallBack