### PR TITLE
Add a tap listener to the view

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -77,6 +77,7 @@ class PdfRendererView @JvmOverloads constructor(
 
     var zoomListener: ZoomListener? = null
     var statusListener: StatusCallBack? = null
+    var tapListener: TapListener? = null
 
     //region Public APIs
     fun isZoomedIn(): Boolean = this::recyclerView.isInitialized && recyclerView.isZoomedIn()
@@ -260,6 +261,10 @@ class PdfRendererView @JvmOverloads constructor(
 
         recyclerView.setOnZoomChangeListener { isZoomedIn, scale ->
             zoomListener?.onZoomChanged(isZoomedIn, scale)
+        }
+
+        recyclerView.setOnTapListener {
+            tapListener?.onTap()
         }
 
         recyclerView.post {
@@ -488,5 +493,9 @@ class PdfRendererView @JvmOverloads constructor(
 
     interface ZoomListener {
         fun onZoomChanged(isZoomedIn: Boolean, scale: Float)
+    }
+
+    fun interface TapListener {
+        fun onTap()
     }
 }

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PinchZoomRecyclerView.kt
@@ -38,6 +38,7 @@ class PinchZoomRecyclerView @JvmOverloads constructor(
     private var posY = 0f
 
     private var zoomChangeListener: ((Boolean, Float) -> Unit)? = null
+    private var tapListener: PdfRendererView.TapListener? = null
 
     private var anchorScale = 1f
     private var anchorFocusY = 0f
@@ -59,6 +60,10 @@ class PinchZoomRecyclerView @JvmOverloads constructor(
 
     fun setOnZoomChangeListener(listener: (isZoomedIn: Boolean, scale: Float) -> Unit) {
         zoomChangeListener = listener
+    }
+
+    fun setOnTapListener(listener: PdfRendererView.TapListener) {
+        tapListener = listener
     }
 
     /**
@@ -291,6 +296,10 @@ class PinchZoomRecyclerView @JvmOverloads constructor(
      * GestureListener handles double-tap zoom.
      */
     private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent): Boolean {
+            tapListener?.onTap()
+            return true
+        }
         override fun onDoubleTap(e: MotionEvent): Boolean {
             if (!isZoomEnabled) return false
 

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/compose/PdfRendererCompose.kt
@@ -30,6 +30,7 @@ fun PdfRendererViewCompose(
     statusCallBack: PdfRendererView.StatusCallBack? = null,
     zoomListener: PdfRendererView.ZoomListener? = null,
     onReady: ((PdfRendererView) -> Unit)? = null,
+    tapListener: PdfRendererView.TapListener? = null
 ) {
     val context = LocalContext.current
     val pdfViewRef = remember { mutableStateOf<PdfRendererView?>(null) }
@@ -83,12 +84,14 @@ fun PdfRendererViewCompose(
             PdfRendererView(ctx).also { view ->
                 view.statusListener = combinedCallback
                 view.zoomListener = zoomListener
+                view.tapListener = tapListener
                 pdfViewRef.value = view
             }
         },
         update = { view ->
             view.statusListener = combinedCallback
             view.zoomListener = zoomListener
+            view.tapListener = tapListener
 
             if (!hasInit) {
                 when {


### PR DESCRIPTION
This is a small feature that would really help me (and a lot of people I guess). It's very difficult to pass events between Android `View`s and composables. This would allow anyone to listen for single taps. For example, I want to use this to toggle the app bar visibility in my application.

---

* New `TapListener` functional interface in `PdfRendererView`
* New `setOnTapListener` method in `PinchZoomRecyclerView`
* New `tapListener` field in `PinchZoomRecyclerView`
* Listen for single tap events in `PinchZoomRecyclerView.GestureListener`
* New `tapListener` field in `PdfRendererView`
* Set tap listener in `PdfRendererView::initializeRenderer`
* New `tapListener` parameter in `PdfRendererViewCompose`
* Set tap listener alongside the status and zoom listeners in `PdfRendererViewCompose`