### PR TITLE
fix: reset page height to WRAP_CONTENT on ViewHolder rebind

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -65,6 +65,10 @@ internal class PdfViewAdapter(
 
             itemBinding.pageView.setImageBitmap(null)
 
+            itemBinding.root.layoutParams = itemBinding.root.layoutParams.apply {
+                this.height = ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+
             itemBinding.pageLoadingLayout.pdfViewPageLoadingProgress.visibility =
                 if (enableLoadingForPages) View.VISIBLE else View.GONE
 


### PR DESCRIPTION
- Stale height from a previously bound page was persisting during fast scroll, causing shorter pages to appear tall and vice versa.