### PR TITLE
fix(pdf): pdf width render

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -60,9 +60,6 @@ internal class PdfViewAdapter(
             hasRealBitmap = false
             scope = MainScope()
 
-            val displayWidth = itemBinding.pageView.width.takeIf { it > 0 }
-                ?: context.resources.displayMetrics.widthPixels
-
             itemBinding.pageView.setImageBitmap(null)
 
             itemBinding.pageLoadingLayout.pdfViewPageLoadingProgress.visibility =
@@ -83,6 +80,9 @@ internal class PdfViewAdapter(
                 }
 
                 renderer.getPageDimensionsAsync(position) { size ->
+                    val displayWidth = itemBinding.pageView.width.takeIf { it > 0 }
+                        ?: context.resources.displayMetrics.widthPixels
+
                     if (currentBoundPage != position) return@getPageDimensionsAsync
 
                     val aspectRatio = size.width.toFloat() / size.height.toFloat()


### PR DESCRIPTION
fix(pdf): ensure pageView width is retrieved correctly for PDF rendering

- Previously, the width of itemBinding.pageView was always 0 at creation, which caused incorrect PDF rendering. This change moves the width calculation so the correct value is used.