### PR TITLE
Fix/pdf width render

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -60,9 +60,6 @@ internal class PdfViewAdapter(
             hasRealBitmap = false
             scope = MainScope()
 
-            val displayWidth = itemBinding.pageView.width.takeIf { it > 0 }
-                ?: context.resources.displayMetrics.widthPixels
-
             itemBinding.pageView.setImageBitmap(null)
 
             itemBinding.pageLoadingLayout.pdfViewPageLoadingProgress.visibility =
@@ -83,6 +80,9 @@ internal class PdfViewAdapter(
                 }
 
                 renderer.getPageDimensionsAsync(position) { size ->
+                    val displayWidth = itemBinding.pageView.width.takeIf { it > 0 }
+                        ?: context.resources.displayMetrics.widthPixels
+
                     if (currentBoundPage != position) return@getPageDimensionsAsync
 
                     val aspectRatio = size.width.toFloat() / size.height.toFloat()

--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewAdapter.kt
@@ -80,7 +80,7 @@ internal class PdfViewAdapter(
                 }
 
                 renderer.getPageDimensionsAsync(position) { size ->
-                    val displayWidth = itemBinding.pageView.width.takeIf { it > 0 }
+                    val displayWidth = itemBinding.pageView.width.takeIf { it > 1 }
                         ?: context.resources.displayMetrics.widthPixels
 
                     if (currentBoundPage != position) return@getPageDimensionsAsync


### PR DESCRIPTION
fix(pdf): correctly retrieve pageView width for PDF rendering in Jetpack Compose
Previously, itemBinding.pageView.width returned 0 for a Dialog at creation and 1 in full screen, causing incorrect PDF rendering.
This change updates the width calculation to ensure the correct value is used in a Jetpack Compose layout.