### PR TITLE
fix(activity): persist source-type + save-to flags across process death

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewerActivity.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfViewerActivity.kt
@@ -82,6 +82,12 @@ class PdfViewerActivity : AppCompatActivity() {
         const val FROM_ASSETS = "from_assests"
         const val TITLE_BEHAVIOR = "title_behavior"
         const val ENABLE_ZOOM = "enable_zoom"
+        // Persist source-type and download-destination flags as intent extras so they survive
+        // process death + activity restoration. Plain companion-object `var`s reset to their
+        // declared defaults when Android reclaims the process, which broke local-file viewing
+        // after restore (see issue #219).
+        const val IS_FROM_PATH = "is_pdf_from_path"
+        const val SAVE_TO_DOWNLOADS_KEY = "save_to_downloads"
         var enableDownload = false
         var isPDFFromPath = false
         var isFromAssets = false
@@ -110,6 +116,8 @@ class PdfViewerActivity : AppCompatActivity() {
                 intent.putExtra(TITLE_BEHAVIOR, it.ordinal)
             }
             intent.putExtra(CACHE_STRATEGY, cacheStrategy.ordinal)
+            intent.putExtra(IS_FROM_PATH, false)
+            intent.putExtra(SAVE_TO_DOWNLOADS_KEY, saveTo == com.rajat.pdfviewer.util.saveTo.DOWNLOADS)
             isPDFFromPath = false
             SAVE_TO_DOWNLOADS = saveTo == com.rajat.pdfviewer.util.saveTo.DOWNLOADS
             return intent
@@ -135,6 +143,8 @@ class PdfViewerActivity : AppCompatActivity() {
             }
             intent.putExtra(ENABLE_ZOOM, enableZoom)
             intent.putExtra(CACHE_STRATEGY, cacheStrategy.ordinal)
+            intent.putExtra(IS_FROM_PATH, true)
+            intent.putExtra(SAVE_TO_DOWNLOADS_KEY, saveTo == com.rajat.pdfviewer.util.saveTo.DOWNLOADS)
             isPDFFromPath = true
             SAVE_TO_DOWNLOADS = saveTo == com.rajat.pdfviewer.util.saveTo.DOWNLOADS
             return intent
@@ -218,6 +228,12 @@ class PdfViewerActivity : AppCompatActivity() {
     private fun extractIntentExtras() {
         enableDownload = intent.getBooleanExtra(ENABLE_FILE_DOWNLOAD, false)
         isFromAssets = intent.getBooleanExtra(FROM_ASSETS, false)
+        // Re-derive source-type + download-destination flags from the persisted intent so
+        // they survive process death. If the extras are missing (caller used a custom Intent
+        // that didn't go through the launchPdfFromX helpers), fall back to the companion's
+        // current static value rather than silently flipping the default.
+        isPDFFromPath = intent.getBooleanExtra(IS_FROM_PATH, isPDFFromPath)
+        SAVE_TO_DOWNLOADS = intent.getBooleanExtra(SAVE_TO_DOWNLOADS_KEY, SAVE_TO_DOWNLOADS)
 
         // Use deprecated getParcelableExtra on Android 13 (API 33) as the new method generates
         // throws a NPE. See: https://github.com/afreakyelf/Pdf-Viewer/issues/244


### PR DESCRIPTION
PdfViewerActivity routes between URL-download and local-file rendering based on isPDFFromPath, a var in the companion object. The same pattern gates SAVE_TO_DOWNLOADS for the download menu. Both are set as side effects of launchPdfFromUrl / launchPdfFromPath and were never written to the intent, so when Android killed the process and restored the activity, the statics reset to their declared defaults (false / true) while the intent's FILE_URL extra still held the original path.

Result: a local file path (set via launchPdfFromPath) was treated as a URL on restore and rejected by PdfDownloader with "Invalid URL Scheme: <path>. Expected HTTP or HTTPS." SAVE_TO_DOWNLOADS had the same bug silently — the download destination flipped after restore.

Fix:
- Persist both flags as new intent extras (IS_FROM_PATH, SAVE_TO_DOWNLOADS_KEY) in launchPdfFromUrl / launchPdfFromPath
- Re-derive both statics from the intent in extractIntentExtras() so state restoration restores correct routing
- Existing static writes kept for back-compat with any caller that reads the companion fields directly

No public API change. Callers that don't go through the launchPdfFromX helpers (custom Intent) fall back to the static's current value, so behaviour is unchanged for them.

Closes #219.